### PR TITLE
修复 kotlin 模板不生成 Dagger**Component 的问题

### DIFF
--- a/NewArmsModule/kotlin.gradle.ftl
+++ b/NewArmsModule/kotlin.gradle.ftl
@@ -1,0 +1,3 @@
+dependencies {
+    kapt rootProject.ext.dependencies["dagger2-compiler"]
+}

--- a/NewArmsModule/kotlin_macros.ftl
+++ b/NewArmsModule/kotlin_macros.ftl
@@ -1,0 +1,49 @@
+<#-- Macro used to add the necessary dependencies to support kotlin to
+an app build.gradle -->
+
+<#macro addKotlinPlugins>
+<#if generateKotlin>
+<#compress>
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
+</#compress>
+</#if>
+</#macro>
+
+<#macro addKotlinDagger2Dependencies>
+<#if generateKotlin>
+<#compress>
+kapt rootProject.ext.dependencies["dagger2-compiler"]
+</#compress>
+</#if>
+</#macro>
+
+<#macro addKotlinDependencies>
+<#if generateKotlin>${getConfigurationName("compile")} "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"</#if>
+</#macro>
+
+// TODO: <apply plugin /> Is adding the dependencies at the *end* of build.gradle
+// TODO: The two macros above, addKotlinPlugins and addKotlinDependencies, are duplicating the work of addAllKotlinDependencies, when
+//       creating a new project (isNewProject == true). The only reason is the above bug on <apply plugin />
+<#macro addAllKotlinDependencies>
+  <#if !isNewProject && ((language!'Java')?string == 'Kotlin')>
+    <apply plugin="kotlin-android" />
+    <apply plugin="kotlin-android-extensions" />
+    <apply plugin="kotlin-kapt" />
+    <merge from="root://gradle-projects/NewArmsModule/kotlin.gradle.ftl"
+        to="${escapeXmlAttribute(projectOut)}/build.gradle" />
+    <#if !hasDependency('org.jetbrains.kotlin:kotlin-stdlib')>
+        <dependency mavenUrl="org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"/>
+		<merge from="root://activities/common/kotlin.gradle.ftl"
+             to="${escapeXmlAttribute(projectLocation)}/build.gradle" />
+    </#if>
+  </#if>
+</#macro>
+
+<#macro addKotlinToBaseProject>
+  <#if (language!'Java')?string == 'Kotlin'>
+    <merge from="root://activities/common/kotlin.gradle.ftl"
+             to="${escapeXmlAttribute(projectLocation)}/build.gradle" />
+  </#if>
+</#macro>

--- a/NewArmsModule/root/build.gradle.ftl
+++ b/NewArmsModule/root/build.gradle.ftl
@@ -1,4 +1,4 @@
-<#import "root://activities/common/kotlin_macros.ftl" as kt>
+<#import "root://gradle-projects/NewArmsModule/kotlin_macros.ftl" as kt>
 apply plugin: 'com.android.application'
 <@kt.addKotlinPlugins />
 
@@ -59,6 +59,7 @@ dependencies {
     
     //tools
     annotationProcessor rootProject.ext.dependencies["dagger2-compiler"]
+    <@kt.addKotlinDagger2Dependencies />
 
     //注意 Arms 核心库现在并不会依赖某个 EventBus, 要想使用 EventBus, 还请在项目中自行依赖对应的 EventBus
     //现在支持两种 EventBus, greenrobot 的 EventBus 和畅销书 《Android源码设计模式解析与实战》的作者 何红辉 所作的 AndroidEventBus


### PR DESCRIPTION
使用 kotlin 时，会在 build.gradle 增加两行 dagger2 所需代码