### PR TITLE
修复使用 kotlin 模板时不会自动创建 Dagger**Component 的问题

### DIFF
--- a/NewArmsModule/dagger2_macros.ftl
+++ b/NewArmsModule/dagger2_macros.ftl
@@ -1,0 +1,15 @@
+<#macro addKaptPlugins>
+<#if generateKotlin>
+<#compress>
+apply plugin: 'kotlin-kapt'
+</#compress>
+</#if>
+</#macro>
+
+<#macro addKaptDependencies>
+<#if generateKotlin>
+<#compress>
+kapt rootProject.ext.dependencies["dagger2-compiler"]
+</#compress>
+</#if>
+</#macro>

--- a/NewArmsModule/root/build.gradle.ftl
+++ b/NewArmsModule/root/build.gradle.ftl
@@ -62,7 +62,7 @@ dependencies {
     
     //tools
     annotationProcessor rootProject.ext.dependencies["dagger2-compiler"]
-	<@dagger2.addKaptDependencies />
+    <@dagger2.addKaptDependencies />
 
     //注意 Arms 核心库现在并不会依赖某个 EventBus, 要想使用 EventBus, 还请在项目中自行依赖对应的 EventBus
     //现在支持两种 EventBus, greenrobot 的 EventBus 和畅销书 《Android源码设计模式解析与实战》的作者 何红辉 所作的 AndroidEventBus

--- a/NewArmsModule/root/build.gradle.ftl
+++ b/NewArmsModule/root/build.gradle.ftl
@@ -1,6 +1,9 @@
 <#import "root://activities/common/kotlin_macros.ftl" as kt>
+<#import "root://gradle-projects/NewArmsModule/dagger2_macros.ftl" as dagger2>
 apply plugin: 'com.android.application'
 <@kt.addKotlinPlugins />
+
+<@dagger2.addKaptPlugins />
 
 android {
     compileSdkVersion rootProject.ext.android["compileSdkVersion"]
@@ -59,6 +62,7 @@ dependencies {
     
     //tools
     annotationProcessor rootProject.ext.dependencies["dagger2-compiler"]
+	<@dagger2.addKaptDependencies />
 
     //注意 Arms 核心库现在并不会依赖某个 EventBus, 要想使用 EventBus, 还请在项目中自行依赖对应的 EventBus
     //现在支持两种 EventBus, greenrobot 的 EventBus 和畅销书 《Android源码设计模式解析与实战》的作者 何红辉 所作的 AndroidEventBus


### PR DESCRIPTION
生成在 kotlin 使用 dagger2 时所需的 kapt 代码